### PR TITLE
Fix spacing in DeltaLang specification heading

### DIFF
--- a/DeltaLang_Specification_v1.md
+++ b/DeltaLang_Specification_v1.md
@@ -34,7 +34,7 @@ Interpretation:
 
 ---
 
-##Example: Maximum Value in Array
+## Example: Maximum Value in Array
 
 ΔLang pseudocode:
 


### PR DESCRIPTION
## Summary
- add missing space in "Maximum Value in Array" heading

## Testing
- `grep -n "Maximum Value in Array" DeltaLang_Specification_v1.md`

------
https://chatgpt.com/codex/tasks/task_e_688d5d9d16e48332878d74d3712f318d