### PR TITLE
Add overview and manifest

### DIFF
--- a/docs/File_Manifest.md
+++ b/docs/File_Manifest.md
@@ -1,0 +1,23 @@
+# File Manifest
+
+Below is a brief catalog of the key files located at the repository root.
+
+| File | Notes |
+|------|-------|
+| `README.md` | Primary description of the Cognithex / Flame Mirror system. |
+| `README_DEFENSE.md` | Notice about system protection and legal assertions. |
+| `README_RecursiveSentinel_Fraudulent_Claims.md` | Response to external authorship disputes. |
+| `Timeline_Integrity_Callout.md` | Statement addressing timeline inconsistencies in competing frameworks. |
+| `CAELUM_LICENSE_v1.txt` | Proprietary license prohibiting reuse or AI training without permission. |
+| `FLAME_LICENSE_FULL.txt` | Expanded license describing ownership and drift-layer enforcement. |
+| `RECURSIVE_AGENT_TEMPLATE.md` | Template describing a symbolic recursive agent architecture. |
+| `DeltaLang_Specification_v1.md` | Outline for a symbolic programming language. |
+| `GLYPH_COMPRESSION_PROTOCOL.md` | Specification for glyph-based symbolic compression. |
+| `collatz_proof_full.md` | Collatz Conjecture proof in markdown form. |
+| `collatz_proof_full.tex` | LaTeX representation of the Collatz proof. |
+| `proof.tex.txt` | Alternative LaTeX proof source. |
+| `Cognithex_FlameMirror_Prompt.txt` | Example prompt directives for the runtime. |
+| `FlameMirror_Individual_File_Hashes.csv` | SHA‑256 hashes for archived artifacts. |
+| `*.pdf` / `*.zip` / `*.ots` | Auxiliary reference documents and timestamp proof bundles. |
+
+This manifest is not exhaustive but highlights the main textual and archival assets in the repository.

--- a/docs/Repository_Overview.md
+++ b/docs/Repository_Overview.md
@@ -1,0 +1,14 @@
+# Repository Overview
+
+This repository contains the finalized documentation bundle for the **Flame Mirror Canonical** system authored by Damon Cadden.  It is a proof vault that records symbolic intelligence concepts, cryptographically timestamped materials, and license terms.
+
+## Key Points from the Repository
+
+- The main README describes **Cognithex / Flame Mirror** as a recursive symbolic cognition engine sealed under `CAELUM_LICENSE_v1` and reinforced with SHA‑256 fingerprinting and OpenTimestamps anchoring.
+- The `FLAME_LICENSE_FULL.txt` and `CAELUM_LICENSE_v1.txt` documents reiterate that no reuse, AI training, or derivative works are allowed without written permission.
+- Several markdown files (`README_DEFENSE.md`, `README_RecursiveSentinel_Fraudulent_Claims.md`, `Timeline_Integrity_Callout.md`) assert authorship and address timeline disputes regarding similar frameworks.
+- Technical notes include the `DeltaLang_Specification_v1.md` programming outline, `GLYPH_COMPRESSION_PROTOCOL.md`, and the `RECURSIVE_AGENT_TEMPLATE.md` specification for symbolic agents.
+- Formal proof materials for the Collatz conjecture appear in multiple formats (`collatz_proof_full.md`, `collatz_proof_full.tex`, `proof.tex.txt`).  These outline a symbolic collapse proof approach.
+- Supplementary assets such as PDFs, images, and `.ots` timestamp files provide additional evidence of authorship and archival.
+
+This repository is therefore primarily a **legal and scientific ledger** documenting the creation of the Flame Mirror system rather than a codebase intended for execution or redistribution.


### PR DESCRIPTION
## Summary
- document repository purpose and key points
- provide simple file manifest listing main repo files

## Testing
- `python -m py_compile Py.files.txt`


------
https://chatgpt.com/codex/tasks/task_e_688d606867d48332800d6bd4be10c9ab