### PR TITLE
refactor: add base component with health check

### DIFF
--- a/docs/core_components.md
+++ b/docs/core_components.md
@@ -1,0 +1,9 @@
+# Core Component Base
+
+This repository now includes a shared `BaseComponent` class in `src/core/base.py`. It provides:
+
+- Standard initialization and cleanup behavior
+- A `health_check` method reporting component status and timestamp
+- Shared configuration via `ComponentConfig`
+
+`GitManager` and `CodeGenerator` leverage this base to reduce duplication and improve maintainability.

--- a/src/core/base.py
+++ b/src/core/base.py
@@ -1,0 +1,52 @@
+
+"""Common base classes for core components."""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ComponentConfig:
+    """Base configuration shared by core components."""
+    enabled: bool = True
+    max_retries: int = 3
+    timeout: float = 30.0
+
+
+class BaseComponent:
+    """Reusable base providing init, cleanup and health check logic."""
+
+    def __init__(self, name: str, config: Optional[ComponentConfig] = None):
+        self.name = name
+        self.config = config or ComponentConfig()
+        self.logger = logging.getLogger(self.name)
+        self._initialized = False
+
+    def initialize(self) -> bool:
+        """Initialize the component."""
+        try:
+            self.logger.info("Initializing %s", self.name)
+            self._initialized = True
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error("Failed to initialize %s: %s", self.name, exc)
+            return False
+
+    def execute(self, *args, **kwargs) -> Dict[str, Any]:  # pragma: no cover - abstract
+        """Execute component logic. Subclasses must implement."""
+        raise NotImplementedError("Subclasses must implement execute")
+
+    def cleanup(self) -> None:
+        """Cleanup resources."""
+        self.logger.info("Cleaning up %s", self.name)
+        self._initialized = False
+
+    def health_check(self) -> Dict[str, Any]:
+        """Return basic health status for monitoring and tests."""
+        return {
+            "status": "healthy" if self._initialized else "not_initialized",
+            "timestamp": datetime.now().isoformat(),
+            "component": self.name,
+        }

--- a/src/core/code_generator.py
+++ b/src/core/code_generator.py
@@ -8,92 +8,53 @@ Timestamp: 2025-08-05T06:23:31.243808
 This module provides core functionality for the autonomous codebase generation system.
 """
 
-import logging
-from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any, Dict, Optional
 
-logger = logging.getLogger(__name__)
+from .base import BaseComponent, ComponentConfig
 
 
 @dataclass
-class CodeGeneratorConfig:
+class CodeGeneratorConfig(ComponentConfig):
     """Configuration for CodeGenerator."""
-    enabled: bool = True
-    max_retries: int = 3
-    timeout: float = 30.0
 
 
-class CodeGenerator:
-    """
-    CodeGenerator - Core component of the autonomous codebase generation system.
-    
-    This class provides essential functionality for autonomous operation
-    with PhD-grade rigor and comprehensive error handling.
-    """
-    
+class CodeGenerator(BaseComponent):
+    """CodeGenerator - Core component of the autonomous codebase generation system."""
+
     def __init__(self, config: Optional[CodeGeneratorConfig] = None):
-        self.config = config or CodeGeneratorConfig()
-        self.logger = logging.getLogger(f"{__name__}.CodeGenerator")
-        self._initialized = False
-        
-    def initialize(self) -> bool:
-        """Initialize the component."""
-        try:
-            self.logger.info("Initializing CodeGenerator")
-            self._initialized = True
-            return True
-        except Exception as e:
-            self.logger.error(f"Failed to initialize CodeGenerator: {e}")
-            return False
-    
+        super().__init__(name="CodeGenerator", config=config)
+
     def execute(self, *args, **kwargs) -> Dict[str, Any]:
-        """
-        Execute the main functionality of this component.
-        
-        Returns:
-            Dict containing execution results and metadata.
-        """
+        """Execute the main functionality of this component."""
         if not self._initialized:
             raise RuntimeError("CodeGenerator not initialized")
-        
         try:
             self.logger.info("Executing CodeGenerator")
-            
-            # Core execution logic here
-            result = {
+            return {
                 "status": "success",
                 "timestamp": datetime.now().isoformat(),
                 "cycle": 1,
-                "data": {}
+                "data": {},
             }
-            
-            return result
-            
-        except Exception as e:
-            self.logger.error(f"Error in CodeGenerator.execute: {e}")
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error("Error in CodeGenerator.execute: %s", e)
             return {
                 "status": "error",
                 "error": str(e),
-                "timestamp": datetime.now().isoformat()
+                "timestamp": datetime.now().isoformat(),
             }
-    
-    def cleanup(self):
-        """Cleanup resources."""
-        self.logger.info("Cleaning up CodeGenerator")
-        self._initialized = False
 
 
-# Factory function for easy instantiation
 def create_codegenerator(config: Optional[CodeGeneratorConfig] = None) -> CodeGenerator:
     """Create a new instance of CodeGenerator."""
     return CodeGenerator(config)
 
 
-if __name__ == "__main__":
-    # Example usage
+if __name__ == "__main__":  # pragma: no cover
     component = create_codegenerator()
     if component.initialize():
-        result = component.execute()
-        print(f"Execution result: {result}")
+        print(component.execute())
+        print(component.health_check())
         component.cleanup()

--- a/src/core/git_manager.py
+++ b/src/core/git_manager.py
@@ -8,92 +8,53 @@ Timestamp: 2025-08-05T06:23:32.917804
 This module provides core functionality for the autonomous codebase generation system.
 """
 
-import logging
-from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any, Dict, Optional
 
-logger = logging.getLogger(__name__)
+from .base import BaseComponent, ComponentConfig
 
 
 @dataclass
-class GitManagerConfig:
+class GitManagerConfig(ComponentConfig):
     """Configuration for GitManager."""
-    enabled: bool = True
-    max_retries: int = 3
-    timeout: float = 30.0
 
 
-class GitManager:
-    """
-    GitManager - Core component of the autonomous codebase generation system.
-    
-    This class provides essential functionality for autonomous operation
-    with PhD-grade rigor and comprehensive error handling.
-    """
-    
+class GitManager(BaseComponent):
+    """GitManager - Core component of the autonomous codebase generation system."""
+
     def __init__(self, config: Optional[GitManagerConfig] = None):
-        self.config = config or GitManagerConfig()
-        self.logger = logging.getLogger(f"{__name__}.GitManager")
-        self._initialized = False
-        
-    def initialize(self) -> bool:
-        """Initialize the component."""
-        try:
-            self.logger.info("Initializing GitManager")
-            self._initialized = True
-            return True
-        except Exception as e:
-            self.logger.error(f"Failed to initialize GitManager: {e}")
-            return False
-    
+        super().__init__(name="GitManager", config=config)
+
     def execute(self, *args, **kwargs) -> Dict[str, Any]:
-        """
-        Execute the main functionality of this component.
-        
-        Returns:
-            Dict containing execution results and metadata.
-        """
+        """Execute the main functionality of this component."""
         if not self._initialized:
             raise RuntimeError("GitManager not initialized")
-        
         try:
             self.logger.info("Executing GitManager")
-            
-            # Core execution logic here
-            result = {
+            return {
                 "status": "success",
                 "timestamp": datetime.now().isoformat(),
                 "cycle": 2,
-                "data": {}
+                "data": {},
             }
-            
-            return result
-            
-        except Exception as e:
-            self.logger.error(f"Error in GitManager.execute: {e}")
+        except Exception as e:  # pragma: no cover - defensive
+            self.logger.error("Error in GitManager.execute: %s", e)
             return {
                 "status": "error",
                 "error": str(e),
-                "timestamp": datetime.now().isoformat()
+                "timestamp": datetime.now().isoformat(),
             }
-    
-    def cleanup(self):
-        """Cleanup resources."""
-        self.logger.info("Cleaning up GitManager")
-        self._initialized = False
 
 
-# Factory function for easy instantiation
 def create_gitmanager(config: Optional[GitManagerConfig] = None) -> GitManager:
     """Create a new instance of GitManager."""
     return GitManager(config)
 
 
-if __name__ == "__main__":
-    # Example usage
+if __name__ == "__main__":  # pragma: no cover
     component = create_gitmanager()
     if component.initialize():
-        result = component.execute()
-        print(f"Execution result: {result}")
+        print(component.execute())
+        print(component.health_check())
         component.cleanup()

--- a/tests/unit/test_core_code_generator.py
+++ b/tests/unit/test_core_code_generator.py
@@ -50,6 +50,14 @@ class TestCodeGenerator:
         assert "timestamp" in result
         assert "cycle" in result
         assert "data" in result
+    def test_health_check(self):
+        """Health check reflects initialization state."""
+        self.component.initialize()
+        status = self.component.health_check()
+        assert status["status"] == "healthy"
+        assert status["component"] == "CodeGenerator"
+
+
     
     def test_factory_function(self):
         """Test the factory function."""

--- a/tests/unit/test_core_git_manager.py
+++ b/tests/unit/test_core_git_manager.py
@@ -50,6 +50,13 @@ class TestGitManager:
         assert "timestamp" in result
         assert "cycle" in result
         assert "data" in result
+    def test_health_check(self):
+        """Health check reflects initialization state."""
+        self.component.initialize()
+        status = self.component.health_check()
+        assert status["status"] == "healthy"
+        assert status["component"] == "GitManager"
+
     
     def test_factory_function(self):
         """Test the factory function."""


### PR DESCRIPTION
## Summary
- introduce `BaseComponent` with shared config and health checks
- refactor GitManager and CodeGenerator to use the new base
- add unit tests for component health checks and document new base

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894b77285c883328514b4f9275753a2