### PR TITLE
Avoid pytest misidentifying core classes as tests

### DIFF
--- a/src/core/test_runner.py
+++ b/src/core/test_runner.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class TestRunnerConfig:
     """Configuration for TestRunner."""
+    __test__ = False
     enabled: bool = True
     max_retries: int = 3
     timeout: float = 30.0
@@ -31,6 +32,8 @@ class TestRunner:
     This class provides essential functionality for autonomous operation
     with PhD-grade rigor and comprehensive error handling.
     """
+
+    __test__ = False
     
     def __init__(self, config: Optional[TestRunnerConfig] = None):
         self.config = config or TestRunnerConfig()


### PR DESCRIPTION
## Summary
- prevent `TestRunner` and its config from being collected as tests
- make test suite run without pytest collection warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b873dd536c8332949d248a9da32f8d